### PR TITLE
Test/e2e weight

### DIFF
--- a/src/weight/app/weight.py
+++ b/src/weight/app/weight.py
@@ -115,7 +115,7 @@ def record_weight():
             containers = [c.strip() for c in containers.split(",") if c.strip()]
         containers_str = ",".join(containers)
 
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
         conn = get_db_connection()
         cursor = conn.cursor(dictionary=True)
@@ -199,7 +199,7 @@ def get_weight():
         t1 = datetime.now().strftime("%Y%m%d") + "000000"
     # If the user didn’t send to, set it to now
     if not t2:
-        t2 = datetime.now().strftime("%Y%m%d%H%M%S")
+        t2 = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     try:
         conn = get_db_connection()
@@ -287,11 +287,11 @@ def get_item(item_id):
     # If the user didn’t send from, set it to today at midnight
     if not t1:
         first_of_month = datetime.now().replace(day=1, hour=0, minute=0, second=0)
-        t1 = first_of_month.strftime("%Y%m%d%H%M%S")
+        t1 = first_of_month.strftime("%Y-%m-%d %H:%M:%S")
 
     # If the user didn’t send to, set it to now
     if not t2:
-        t2 = datetime.now().strftime("%Y%m%d%H%M%S")
+        t2 = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     conn = None
     cursor = None
@@ -380,8 +380,11 @@ def process_csv(content, conn):
                 raise ValueError(f"Missing or unsupported unit in line: {','.join(row)}")
 
             cursor.execute("""
-                INSERT OR REPLACE INTO containers_registered (container_id, weight, unit)
+                INSERT INTO containers_registered (container_id, weight, unit)
                 VALUES (%s, %s, %s)
+                ON DUPLICATE KEY UPDATE 
+                    weight = VALUES(weight),
+                    unit = VALUES(unit)
             """, (cid, int(float(value)), unit))
     finally:
         if cursor:
@@ -410,8 +413,11 @@ def process_json(content, conn):
                 raise ValueError(f"Missing fields in entry: {entry}")
 
             cursor.execute("""
-                INSERT OR REPLACE INTO containers_registered (container_id, weight, unit)
+                INSERT INTO containers_registered (container_id, weight, unit)
                 VALUES (%s, %s, %s)
+                ON DUPLICATE KEY UPDATE 
+                    weight = VALUES(weight),
+                    unit = VALUES(unit)
             """, (cid.strip(), int(float(weight)), unit.lower()))
     finally:
         if cursor:
@@ -463,7 +469,7 @@ def get_unknown():
 
     try:
         # Get all registered container IDs
-        cursor.execute("SELECT container_id FROM registered_containers")
+        cursor.execute("SELECT container_id FROM containers_registered")
         registered = set(row[0] for row in cursor.fetchall())
 
         # Get all container lists from transactions table

--- a/src/weight/requirements.txt
+++ b/src/weight/requirements.txt
@@ -12,6 +12,7 @@ pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-mock>=3.10.0
 coverage>=7.0.0
+requests==2.31.0
 
 # Additional testing utilities (optional but recommended)
 pytest-html>=3.1.0          # For HTML test reports

--- a/src/weight/tests/test_e2e.py
+++ b/src/weight/tests/test_e2e.py
@@ -1,0 +1,91 @@
+import requests
+import time
+import os
+
+BASE_URL = os.getenv("BASE_URL", "http://localhost:5000")
+
+def wait_for_service():
+    for _ in range(30):
+        try:
+            r = requests.get(f"{BASE_URL}/health")
+            if r.status_code == 200:
+                return
+        except Exception:
+            pass
+        time.sleep(2)
+    raise RuntimeError("Service not ready")
+
+def test_00_service_up():
+    wait_for_service()
+    r = requests.get(f"{BASE_URL}/")
+    assert r.status_code == 200
+    assert "Weight service" in r.text
+
+
+def test_01_post_in_and_out_weight():
+    # 1. IN transaction
+    payload_in = {
+        "direction": "in",
+        "truck": "TRUCK123",
+        "containers": ["C1", "C2"],
+        "weight": 10000,
+        "unit": "kg"
+    }
+    r = requests.post(f"{BASE_URL}/weight", json=payload_in)
+    assert r.status_code == 201
+    in_id = r.json()["id"]
+
+    # 2. Attempt duplicate in without force (should fail)
+    r2 = requests.post(f"{BASE_URL}/weight", json=payload_in)
+    assert r2.status_code == 400
+
+    # 3. Duplicate in with force
+    payload_in["force"] = True
+    r3 = requests.post(f"{BASE_URL}/weight", json=payload_in)
+    assert r3.status_code == 201
+
+    # 4. OUT transaction (truckTara=6000)
+    payload_out = {
+        "direction": "out",
+        "truck": "TRUCK123",
+        "containers": ["C1", "C2"],
+        "weight": 6000,
+    }
+    r4 = requests.post(f"{BASE_URL}/weight", json=payload_out)
+    assert r4.status_code == 201
+    out_json = r4.json()
+    assert "truckTara" in out_json
+    assert "neto" in out_json
+
+
+def test_02_get_weight_list():
+    r = requests.get(f"{BASE_URL}/weight")
+    assert r.status_code in (200, 404)
+
+
+def test_03_get_session_by_id():
+    # Take the latest session ID from /weight
+    r = requests.get(f"{BASE_URL}/weight")
+    if r.status_code == 200:
+        session_id = r.json()[0]["id"]
+        r2 = requests.get(f"{BASE_URL}/session/{session_id}")
+        assert r2.status_code == 200
+
+
+def test_04_item_endpoint():
+    r = requests.get(f"{BASE_URL}/item/TRUCK123")
+    assert r.status_code in (200, 404)
+
+
+def test_05_batch_weight_csv(tmp_path):
+    csv_file = tmp_path / "containers.csv"
+    csv_file.write_text("C1,100kg\nC2,120kg\n")
+    with open(csv_file, "rb") as f:
+        r = requests.post(f"{BASE_URL}/batch-weight", files={"file": f})
+    assert r.status_code == 201
+
+
+def test_06_unknown():
+    r = requests.get(f"{BASE_URL}/unknown")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)

--- a/src/weight/tests/test_e2e.py
+++ b/src/weight/tests/test_e2e.py
@@ -23,20 +23,23 @@ def test_00_service_up():
 
 
 def test_01_post_in_and_out_weight():
-    # 1. IN transaction
+    # 1. IN transaction with force=True (should succeed)
     payload_in = {
         "direction": "in",
         "truck": "TRUCK123",
         "containers": ["C1", "C2"],
         "weight": 10000,
-        "unit": "kg"
+        "unit": "kg",
+        "force": True
     }
     r = requests.post(f"{BASE_URL}/weight", json=payload_in)
     assert r.status_code == 201
     in_id = r.json()["id"]
 
-    # 2. Attempt duplicate in without force (should fail)
-    r2 = requests.post(f"{BASE_URL}/weight", json=payload_in)
+    # 2. Attempt duplicate IN without force (should fail)
+    payload_in_no_force = payload_in.copy()
+    payload_in_no_force.pop("force")  # remove force or set to False
+    r2 = requests.post(f"{BASE_URL}/weight", json=payload_in_no_force)
     assert r2.status_code == 400
 
     # 3. Duplicate in with force


### PR DESCRIPTION
- timeDate format changed to a SQL-suitable one.
- csv & json processing changed query to avoid duplicate issues.
- unknown API containers_registered instead of registered_containers.

added 7 E2E tests

to run:
docker compose --env-file .env up --build
pytest -vv tests/test_e2e.py